### PR TITLE
Fix content changing on Items in Folders

### DIFF
--- a/lib/activesp/item.rb
+++ b/lib/activesp/item.rb
@@ -158,7 +158,11 @@ module ActiveSP
     
     def content=(data)
       @list.when_list { raise TypeError, "a list has attachments" }
-      @list.when_document_library { @list.create_document(:overwrite => true, :content => data, "FileLeafRef" => original_attributes["FileLeafRef"]) }
+      @list.when_document_library do
+        params = {:overwrite => true, :content => data, "FileLeafRef" => original_attributes["FileLeafRef"]}
+        params[:folder] = folder.absolute_url if folder
+        @list.create_document params
+      end
       @list.raise_on_unknown_type
     end
     


### PR DESCRIPTION
Because the List is used to overwrite the file and no folder param is
passed, the URL for the List is used in the destination URL. This creates
a new document in the root of the List and leaves the actual one
unchanged.
